### PR TITLE
Fix: Permission Override Signature

### DIFF
--- a/android/src/main/java/com/regula/documentreader/RNRegulaDocumentReaderModule.kt
+++ b/android/src/main/java/com/regula/documentreader/RNRegulaDocumentReaderModule.kt
@@ -79,7 +79,7 @@ class RNRegulaDocumentReaderModule(rc: ReactApplicationContext) : ReactContextBa
         onActivityResult(requestCode, resultCode, data)
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?) = com.regula.documentreader.onRequestPermissionsResult(requestCode, permissions!!, grantResults!!)
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array, grantResults: IntArray) = com.regula.documentreader.onRequestPermissionsResult(requestCode, permissions, grantResults)
 }
 
 fun sendEvent(event: String, data: Any? = "") {


### PR DESCRIPTION
Signature for `onRequestPermissionsResult` seems to be off. We're getting build errors on our end, so I'm not sure if this changed recently.