### PR TITLE
Update podspec source to use Git repository

### DIFF
--- a/RNDocumentReaderApi.podspec
+++ b/RNDocumentReaderApi.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = { 'RegulaForensics' => 'support@regulaforensics.com' }
   s.homepage     = 'https://regulaforensics.com'
 
-  s.source       = { :http => 'file:' + __dir__ }
+  s.source       = { :git => "https://github.com/regulaforensics/react-native-document-reader.git"}
   s.ios.deployment_target = '13.0'
   s.source_files  = "ios/*.{h,m}"
   s.dependency 'DocumentReader', '8.3.5107'


### PR DESCRIPTION
This avoids an issue where the computed checksum of the podspec is different on every system, preventing the sharing of a deterministic Podfile.lock in a team of more than one person.

This fixes https://github.com/regulaforensics/react-native-document-reader/issues/17